### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 
 	<!-- Component Version Properties -->
 	<properties>
-		<spring.version>4.3.10.RELEASE</spring.version>
-		<fileupload.version>1.3.2</fileupload.version>
+		<spring.version>4.3.20.RELEASE</spring.version>
+		<fileupload.version>1.5</fileupload.version>
 	</properties>
 
 	<!-- Dependencies begin here -->
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>4.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-core` | 4.3.10.RELEASE | 5.2.18.RELEASE | No |
| MAVEN | `commons-fileupload:commons-fileupload` | 1.3.2 | 1.5 | No |
| MAVEN | `org.springframework:spring-webmvc` | 4.3.10.RELEASE | 4.3.20.RELEASE | No |
| MAVEN | `org.apache.commons:commons-collections4` | 4.0 | 4.1 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/PaaiwbY/scans/47940463).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-7581ad1cbbf96e3278a8f0469755321f78192a79729170a5f3d936f3ebad669d -->
